### PR TITLE
Fix error writing tmp file using plugin with remote unix system

### DIFF
--- a/plugins/check_snmp_process.pl
+++ b/plugins/check_snmp_process.pl
@@ -640,6 +640,10 @@ if (defined ($o_cpu) ) {
   #### Read file
   $temp_file_name=$o_descr;
   $temp_file_name =~ s/ /_/g;
+  $temp_file_name =~ s/\//_/g;
+  $temp_file_name =~ s/-//g;
+  $temp_file_name =~ s/=//g;
+  $temp_file_name = substr($temp_file_name,0,40);
   $temp_file_name = $o_base_dir . $o_host ."." . $temp_file_name; 
   # First, read entire file
   my @ret_array=read_file($temp_file_name,$n_items_check);


### PR DESCRIPTION
Hallo Micha,
mit dem Fix werden die Temp-Dateien richtig erstellt, wenn man das Plugin nutzt um auf Unix Systemen die Prozesse abfragen möchte und Perfdaten ermitteln möchte.
Gruß
Sascha
