### PR TITLE
Fix, check_snmtp_load output 

### DIFF
--- a/plugins/check_snmp_load.pl
+++ b/plugins/check_snmp_load.pl
@@ -284,7 +284,6 @@ sub check_options {
 sub is_legacy_snmp_version {
     my $version=Net::SNMP->VERSION; #using a variable for easier testing
     if ($version=~/^\D*(\d)/ and $1 < 4){
-        print "$1 wee";
         return 1;
     }else{
         return 0;


### PR DESCRIPTION
remove print "$1 wee" from check_snmp_load, apparently used to test the SNMP version fix,
this was called every time the snmp version is checked, prepending "1 wee" to the output.

1 wee1 weeLoad (CPUs: 4) : 0.06 0.06 0.01 : OK | load_1_min=0.06;60;120 load_5_min=0.06;40;100 load_15_min=0.01;20;80