### PR TITLE
pnp need perf-data with always same order

### DIFF
--- a/plugins/check_snmp_int.pl
+++ b/plugins/check_snmp_int.pl
@@ -483,7 +483,7 @@ if (defined($o_highperf)) {
 # and put the oid to query in an array
 
 verb("Filter : $o_descr");
-foreach my $key ( keys %$resultat) {
+foreach my $key (sort { $$resultat{$a} cmp $$resultat{$b} } keys %$resultat) {
    verb("OID : $key, Desc : $$resultat{$key}");
    # test by regexp or exact match
    my $test = defined($o_noreg) 


### PR DESCRIPTION
pnp draws nasty graphs until the order of the perf-data is always the same. Fixed by adding a missing sort in check_snmp_int.pl and check_snmp_storage.pl.