### PR TITLE
pnp need perf-data with always same order

### DIFF
--- a/plugins/check_snmp_storage.pl
+++ b/plugins/check_snmp_storage.pl
@@ -465,7 +465,7 @@ my $perf_out=	undef;
 
 verb("Filter : $o_descr");
 
-foreach my $key ( keys %$resultat) {
+foreach my $key (sort { $$resultat{$a} cmp $$resultat{$b} } keys %$resultat) {
    verb("OID : $key, Desc : $$resultat{$key}");
    # test by regexp or exact match / include or exclude
    if (defined($o_negate)) {


### PR DESCRIPTION
pnp draws nasty graphs until the order of the perf-data is always the same. Fixed by adding a missing sort.