### PR TITLE
check_snmp_storage: fix SNMP error handling, see #33

### DIFF
--- a/plugins/check_snmp_storage.pl
+++ b/plugins/check_snmp_storage.pl
@@ -598,6 +598,15 @@ if (version->parse(Net::SNMP->VERSION) < 4) {
     $result = $session->get_request(@oids);
 } else {
     $result = $session->get_request(Varbindlist => \@oids);
+}
+
+if (!defined($result)) {
+    printf("ERROR getting OIDs: %s.\n", $session->error);
+    $session->close;
+    exit $ERRORS{"UNKNOWN"};
+}
+
+if (version->parse(Net::SNMP->VERSION) >= 4) {
     foreach my $key (sort keys %$result) {
 
         # Fix for filesystems larger 2 TB. More than 2 TB will cause an error because
@@ -611,12 +620,6 @@ if (version->parse(Net::SNMP->VERSION) < 4) {
         }
         verb("$key  x $$result{$key}");
     }
-}
-
-if (!defined($result)) {
-    printf("ERROR: Size table :%s.\n", $session->error);
-    $session->close;
-    exit $ERRORS{"UNKNOWN"};
 }
 
 $session->close;


### PR DESCRIPTION
It turns out the call to `session->errors` was already here but it was never reached because of the sort placed before it. I moved the sort after the check for an undefined `$result`.

fixes #33 