### PR TITLE
fix perf_out not defined error

### DIFF
--- a/plugins/check_snmp_int.pl
+++ b/plugins/check_snmp_int.pl
@@ -993,24 +993,25 @@ alarm(0);
 
 # Check if all interface are OK
 if ($num_ok == $num_int) {
+    my $is_perf_defined = defined($perf_out) && defined($o_perf);
     if ($final_status == 0) {
         print $print_out, ":", $num_ok, " UP: OK";
-        if (defined($o_perf)) { print " | ", $perf_out; }
+        if ($is_perf_defined) { print " | ", $perf_out; }
         print "\n";
         exit $ERRORS{"OK"};
     } elsif ($final_status == 1) {
         print $print_out, ":(", $num_ok, " UP): WARNING";
-        if (defined($o_perf)) { print " | ", $perf_out; }
+        if ($is_perf_defined) { print " | ", $perf_out; }
         print "\n";
         exit $ERRORS{"WARNING"};
     } elsif ($final_status == 2) {
         print $print_out, ":(", $num_ok, " UP): CRITICAL";
-        if (defined($o_perf)) { print " | ", $perf_out; }
+        if ($is_perf_defined) { print " | ", $perf_out; }
         print "\n";
         exit $ERRORS{"CRITICAL"};
     } else {
         print $print_out, ":(", $num_ok, " UP): UNKNOWN";
-        if (defined($perf_out)) { print " | ", $perf_out; }
+        if ($is_perf_defined) { print " | ", $perf_out; }
         print "\n";
         exit $ERRORS{"UNKNOWN"};
     }


### PR DESCRIPTION
If interface is down then there is no perf_data and plugin is crashing.
I added simple check to just avoid printing perf_data if there are no `perf_out`.